### PR TITLE
Update docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,4 +28,4 @@ services:
       - INFLUXDB_USERNAME=user
       - INFLUXDB_PASSWORD=user12345
     volumes:
-      - ./gfdata:/var/lib/grafana
+      - ./gfdata:/var/lib/root


### PR DESCRIPTION
Migrate to v5.1 or later
The Docker container for Grafana has seen a major rewrite for 5.1.

Important changes

File ownership is no longer modified during startup with chown. Default user ID is now 472 instead of 104.
Removed the following implicit volumes:
/var/lib/grafana
/etc/grafana
/var/log/grafana
Removal of implicit volumes
Previously /var/lib/grafana, /etc/grafana and /var/log/grafana were defined as volumes in the Dockerfile. This led to the creation of three volumes each time a new instance of the Grafana container started, whether you wanted it or not.

You should always be careful to define your own named volume for storage, but if you depended on these volumes, then you should be aware that an upgraded container will no longer have them.

Warning: When migrating from an earlier version to 5.1 or later using Docker compose and implicit volumes, you need to use docker inspect to find out which volumes your container is mapped to so that you can map them to the upgraded container as well. You will also have to change file ownership (or user) as documented below.

User ID changes
In Grafana v5.1, we changed the ID and group of the Grafana user and in v7.3 we changed the group. Unfortunately this means that files created prior to v5.1 won’t have the correct permissions for later versions. We made this change so that it would be more likely that the Grafana users ID would be unique to Grafana. For example, on Ubuntu 16.04 104 is already in use by the syslog user.

Version	User	User ID	Group	Group ID
< 5.1	grafana	104	grafana	107
>= 5.1	grafana	472	grafana	472
>= 7.3	grafana	472	root	0
There are two possible solutions to this problem. Either you start the new container as the root user and change ownership from 104 to 472, or you start the upgraded container as user 104.

Reference
http://docs.grafana.org/installation/docker/#migrate-to-v51-or-later